### PR TITLE
Added the installation of the qtdeclarative and qtquickcontrols2 pack…

### DIFF
--- a/.github/workflows/centos.yml
+++ b/.github/workflows/centos.yml
@@ -64,7 +64,7 @@ jobs:
             python3 -m pip install -U pip
             python3 -m pip install aqtinstall
             aqt install-qt linux desktop ${{ matrix.qt-version }} -O /Qt \
-            --archives qtbase qtmultimedia qtsvg qttools qtserialport qtimageformats icu qtwayland ${{ matrix.qjsengine == 'qjsengine' && 'qtdeclarative' || '-m qtscript' }}
+            --archives qtbase qtmultimedia qtsvg qttools qtserialport qtimageformats icu qtwayland qtdeclarative qtquickcontrols2 ${{ matrix.qjsengine == 'qjsengine' && 'qtdeclarative' || '-m qtscript' }}
             Qt5_Dir=$(ls -1d /Qt/5*/* | head -n 1)
             echo "Qt5_Dir=${Qt5_Dir}" >> $GITHUB_ENV
             echo "${Qt5_Dir}/bin" >> $GITHUB_PATH

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -81,7 +81,7 @@ jobs:
           version: ${{matrix.qt-version}}
           arch: win32_mingw${{matrix.mingw-short-version}}
           modules: 'qtscript'
-          archives: 'qtbase qtsvg qtserialport qtmultimedia qtwinextras qtimageformats i686 qttools'
+          archives: 'qtbase qtsvg qtserialport qtmultimedia qtwinextras qtimageformats i686 qttools qtdeclarative qtquickcontrols2'
           tools: 'tools_mingw,qt.tools.win32_mingw${{matrix.mingw-short-version}}0'
           extra: '--external 7z'
 


### PR DESCRIPTION
…ages in CI.

To run CI with a new interface implemented in QML, need to install the qtdeclarative and qtquickcontrols2 packages.